### PR TITLE
Fixed malformed invalid XML in JSword.checkstyle.xml

### DIFF
--- a/JSword.checkstyle.xml
+++ b/JSword.checkstyle.xml
@@ -311,7 +311,7 @@
     <module name="OneStatementPerLine"/>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="PackageDeclaration"/>
-    <!--  <module name="ParameterAssignment"/>
+    <!--  <module name="ParameterAssignment"/> -->
     <!-- JSword does not require "this"
     <module name="RequireThis"/>
     -->


### PR DESCRIPTION
(introduced in git commit c0b3b52aa)