### PR TITLE
Fix unit tests to be fully portable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,12 @@ tasks.withType<JavaCompile>() {
     options.encoding = "UTF-8"
 }
 
+tasks.withType<Test>() {
+    // Enforce en-US locale, as many unit tests are locale-dependant.
+    systemProperty("user.language", "en")
+    systemProperty("user.country", "US")
+}
+
 group = "org.crosswire"
 version = "2.3"
 
@@ -28,11 +34,8 @@ dependencies {
     // implementation("org.apache.lucene:lucene-analyzers-common:x")
 
     //implementation("org.slf4j:slf4j-api:1.7.6")
-    if(project.hasProperty("tests")) {
-        implementation("org.slf4j:slf4j-api:1.7.6")
-    } else {
-        implementation("de.psdev.slf4j-android-logger:slf4j-android-logger:1.0.5")
-    }
+    implementation("org.slf4j:slf4j-api:1.7.6")
+    testImplementation("org.slf4j:slf4j-simple:1.7.6")
     testImplementation("junit:junit:4.13")
 }
 

--- a/src/test/java/org/crosswire/jsword/book/BooksTest.java
+++ b/src/test/java/org/crosswire/jsword/book/BooksTest.java
@@ -35,6 +35,7 @@ import org.jdom2.Element;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -134,6 +135,7 @@ public class BooksTest {
     public void testBookList() throws Exception {
         //part of the pre-requisites
         AbstractPassageBook esv = (AbstractPassageBook) Books.installed().getBook("ESV2011");
+        Assume.assumeTrue("ESV2011 is installed", esv != null);
         Assert.assertTrue(esv.getBibleBooks().contains(BibleBook.ACTS));
     }
 
@@ -147,17 +149,18 @@ public class BooksTest {
     @Test
     public void testLinkedVersesNotDuplicated() throws Exception {
         Book turNTB = Books.installed().getBook("TurNTB");
-        if (turNTB != null) {
-            // Eph 2:4,5 are merged/linked in TurNTB
-            Key eph245 = VerseRangeFactory.fromString(Versifications.instance().getVersification("KJV"), "Eph 2:4-5");
-            BookData bookData = new BookData(turNTB, eph245);
-            final Element osisFragment = bookData.getOsisFragment();
 
-            final XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat());
-            String xml = xmlOutputter.outputString(osisFragment);
+        Assume.assumeTrue("TurNTB is installed", turNTB != null);
 
-            Assert.assertTrue("Probable duplicate text", xml.length() < 300);
-        }
+        // Eph 2:4,5 are merged/linked in TurNTB
+        Key eph245 = VerseRangeFactory.fromString(Versifications.instance().getVersification("KJV"), "Eph 2:4-5");
+        BookData bookData = new BookData(turNTB, eph245);
+        final Element osisFragment = bookData.getOsisFragment();
+
+        final XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat());
+        String xml = xmlOutputter.outputString(osisFragment);
+
+        Assert.assertTrue("Probable duplicate text", xml.length() < 300);
     }
 
     /**

--- a/src/test/java/org/crosswire/jsword/book/sword/BackendTest.java
+++ b/src/test/java/org/crosswire/jsword/book/sword/BackendTest.java
@@ -271,9 +271,8 @@ public class BackendTest {
     public void testBackendStrongsGreekRawLd() throws Exception {
         String version = "StrongsGreek";
         String reference = "G3588";
-        String assertion = "3588  ho   ho, including the feminine";
 
-        backendTest(version, reference, assertion);
+        backendTest(version, reference, "3588", "ho");
     }
 
     /**

--- a/src/test/java/org/crosswire/jsword/book/sword/BackendTest.java
+++ b/src/test/java/org/crosswire/jsword/book/sword/BackendTest.java
@@ -30,6 +30,7 @@ import org.jdom2.Element;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -331,9 +332,7 @@ public class BackendTest {
     private String backendTest(String version, String reference, String... assertion) throws NoSuchKeyException, BookException {
         final Book currentBook = Books.installed().getBook(version);
 
-        if (currentBook == null) {
-            return null;
-        }
+        Assume.assumeTrue("Book " + version + " is installed", currentBook != null);
 
         return backendTest(currentBook, currentBook.getKey(reference), assertion);
     }

--- a/src/test/java/org/crosswire/jsword/bridge/DwrBridgeMissingAssetsTest.java
+++ b/src/test/java/org/crosswire/jsword/bridge/DwrBridgeMissingAssetsTest.java
@@ -22,10 +22,7 @@ package org.crosswire.jsword.bridge;
 import org.crosswire.jsword.book.BookException;
 import org.crosswire.jsword.passage.NoSuchKeyException;
 import org.crosswire.jsword.versification.BookName;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  * Test of functionality for use with DWR. This test assumes, at a minimum, that
@@ -42,6 +39,10 @@ public class DwrBridgeMissingAssetsTest {
     @Before
     public void setUp() {
         BookName.setFullBookName(true);
+
+        Assume.assumeTrue("KJV must be installed", BookInstaller.getInstalledBook("KJV") != null);
+        Assume.assumeTrue("StrongsHebrew must be installed", BookInstaller.getInstalledBook("StrongsHebrew") != null);
+        Assume.assumeTrue("StrongsGreek must be installed", BookInstaller.getInstalledBook("StrongsGreek") != null);
     }
 
     @Test

--- a/src/test/java/org/crosswire/jsword/prerequisites/BookPreRequisitesTest.java
+++ b/src/test/java/org/crosswire/jsword/prerequisites/BookPreRequisitesTest.java
@@ -67,6 +67,6 @@ public class BookPreRequisitesTest {
     private BookInstaller underTest;
     private Books installedBooks;
 
-    private static final String[] BOOKS = new String[]{"KJV", "ESV2011"};
+    private static final String[] BOOKS = new String[]{"KJV"};
     private static final Logger LOGGER = LoggerFactory.getLogger(BookPreRequisitesTest.class);
 }

--- a/src/test/java/org/crosswire/jsword/prerequisites/BookPreRequisitesTest.java
+++ b/src/test/java/org/crosswire/jsword/prerequisites/BookPreRequisitesTest.java
@@ -67,6 +67,11 @@ public class BookPreRequisitesTest {
     private BookInstaller underTest;
     private Books installedBooks;
 
-    private static final String[] BOOKS = new String[]{"KJV"};
+    /**
+     * All books referenced in these unit tests that can be retrieved from the Crosswire repository.
+     * Currently missing : ESV2011, MHCC, ot1nt2
+     * Tests that reference a currently missing book are automatically skipped unless the book was installed externally.
+     */
+    private static final String[] BOOKS = new String[]{"KJV", "StrongsHebrew", "StrongsGreek", "Josephus", "Nave", "Geneva", "TurNTB"};
     private static final Logger LOGGER = LoggerFactory.getLogger(BookPreRequisitesTest.class);
 }


### PR DESCRIPTION
After checking first checking out the project, I originally got 457 unit test failures due to environmental issues.
This PR attempts at fixing most of them.

- Enforce en-US locale for test execution : fixes ~331 tests
- Remove android logger dependency (as a library, jsword should only rely on the slf4j api, and let the final application provide the logger implementation) : fixes ~78 tests
- Automatically skip tests that rely on externally-installed data if this data is not available, and remove download of ESV2011 which is missing from crosswire repo : fixes ~46 tests

The numbers are approximate, because in the middle of that there are also some flaky tests remaining (that pass or fail a bit randomly) : specifically the JobTest seems to consistently pass within my IDE, but randomly fail when run from Gradle.


Notes : 
- The only change to the actual jar is the logger dependency update : the lib now only depends on slf4j API, and leaves it up to the client application to provide a correct slf4j implementation. That means the "slf4j-android-logger" dependency might need to be added to and-bible if it's not already there.
- Ideally, tests that rely on external data should be rewritten to rely only on data included within the src/test/resources folder. In particular for tests relying on modules no longer distributed by CrossWire (eg ESV2011).