### PR TITLE
Fix strongs tokenizing filter

### DIFF
--- a/src/main/java/org/crosswire/jsword/index/lucene/analysis/StrongsNumberFilter.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/analysis/StrongsNumberFilter.java
@@ -21,9 +21,11 @@ package org.crosswire.jsword.index.lucene.analysis;
 
 import java.io.IOException;
 
+import org.apache.lucene.analysis.FilteringTokenFilter;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.crosswire.jsword.JSMsg;
 import org.crosswire.jsword.book.study.StrongsNumber;
 import org.slf4j.Logger;
@@ -35,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * @see gnu.lgpl.License The GNU Lesser General Public License for details.
  * @author DM Smith
  */
-public class StrongsNumberFilter extends TokenFilter {
+public class StrongsNumberFilter extends FilteringTokenFilter {
 
     /**
      * Construct filtering <i>in</i>.
@@ -44,72 +46,29 @@ public class StrongsNumberFilter extends TokenFilter {
      */
     public StrongsNumberFilter(TokenStream in) {
         super(in);
+        this.termAtt = addAttribute(CharTermAttribute.class);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.apache.lucene.analysis.TokenStream#incrementToken()
-     */
     @Override
-    public boolean incrementToken() throws IOException {
-        // If the term is suffixed with '!a' or 'a', where 'a' is a sequence of
-        // 1 or more letters
-        // then create a token without the suffix and also for the whole.
+    public boolean accept() {
+        boolean valid;
+        String tokenText = termAtt.toString();
         if (number == null) {
-            // Need to loop over invalid tokens
-            while (input.incrementToken()) {
-                String tokenText = termAtt.toString();
-
-                number = new StrongsNumber(tokenText);
-
-                // Skip invalid Strong's Numbers.
-                // Still need to return true as there may be more tokens to filter.
-                if (!number.isValid()) {
-                    // TRANSLATOR: User error condition: Indicates that what was given is not a Strong's Number. {0} is a placeholder for the bad Strong's Number.
-                    log.warn(JSMsg.gettext("Not a valid Strong's Number \"{0}\"", tokenText));
-
-                    // Go get the next token
-                    continue;
-                }
-
-                String s = number.getStrongsNumber();
-                termAtt.setEmpty().append(s);
-
-                // If the number had a part keep it around for the next call
-                // TODO(DMS): if there is a part, then treat as a synonym,
-                //      setting the same position increment.
-                if (!number.isPart()) {
-                    number = null;
-                }
-
-                // incrementToken returned a value. There may be more input.
-                return true;
+            number = new StrongsNumber(tokenText);
+            valid = number.isValid();
+            termAtt.setEmpty().append(number.getStrongsNumber());
+            if (!number.isPart()) {
+                number = null;
             }
-
-            // There was no more input
-            return false;
+        } else {
+            valid = number.isValid();
+            termAtt.setEmpty().append(number.getFullStrongsNumber());
+            number = null;
         }
-
-        // Process the Strong's number with the !a
-        termAtt.setEmpty().append(number.getFullStrongsNumber());
-        // We are done with the Strong's Number so mark it as used
-        number = null;
-        // We are working on a value returned by incrementToken.
-        // There may be more input.
-        return true;
-    }
-
-    /* Define to quite FindBugs */
-    @Override
-    public boolean equals(Object obj) {
-        return super.equals(obj);
-    }
-
-    /* Define to quite FindBugs */
-    @Override
-    public int hashCode() {
-        return super.hashCode();
+        if (!valid) {
+            log.warn(JSMsg.gettext("Not a valid Strong's Number \"{0}\"", tokenText));
+        }
+        return valid;
     }
 
     private CharTermAttribute termAtt;


### PR DESCRIPTION
Previous version gave a null pointer exception on termAtt. After that, it gave issues due to incorrect position increments. I decided to extend FilteringTokenFilter instead of TokenFilter to defer positioning and only handle accepting of tokens, which simplifies the code significantly.